### PR TITLE
docs: clarify safety limits and update CLI reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,24 @@ It follows a BMSSP-style divide-and-conquer design (levels, `FindPivots`, bounde
 
 * Edge weights must be **non-negative**. Supplying a negative weight raises a
   `GraphFormatError` that points to the exact offending edge.
+* The BMSSP solver includes **safety limits** (caps on iterations, recursion
+  depth, and frontier size) to prevent runaway behavior on large graphs. If a
+  cap is hit, the solver may terminate early and leave some reachable vertices
+  at `inf` while `dijkstra_reference` continues to find them. You can detect
+  this via `SSSPSolver.summary()` and checking whether
+  `iterations_protected > 0`. These safety limits are not currently exposed as
+  public configuration knobs.
+
+## Large graphs
+
+If you see unexpectedly many `inf` distances on large networks, the solver may
+have hit its safety limits. To diagnose:
+* Call `SSSPSolver.summary()` and check if `iterations_protected > 0`.
+
+Workarounds (until limits are configurable):
+* For guaranteed reachability parity, use `dijkstra_reference`.
+* Try `frontier="heap"` with `use_transform=False`, which can reduce the chance
+  of hitting safety caps at the cost of performance.
 
 ## Documentation
 
@@ -99,6 +117,15 @@ poetry run ssspx --random --n 1000 --m 5000 --source 0 \
 # Reproducible random graph
 poetry run ssspx --random --n 10 --m 20 --seed 123
 
+# Multiple sources + a path to a target
+poetry run ssspx --edges docs/examples/small.csv --sources 0,2 --target 3
+
+# Emit structured log line and write metrics JSON
+poetry run ssspx --edges docs/examples/small.csv --log-json --metrics-out metrics.json
+
+# Print a sample CSV to stdout
+poetry run ssspx --example
+
 # Profiling to file + brief text report on stderr
 poetry run ssspx --random --n 5000 --m 20000 --source 0 \
   --frontier block --profile --profile-out prof.cprof 2> prof.txt
@@ -106,6 +133,52 @@ poetry run ssspx --random --n 5000 --m 20000 --source 0 \
 # Structured log line with counters
 poetry run ssspx --random --n 10 --m 20 --log-json
 ```
+
+CLI notes:
+* Results are emitted as JSON to stdout unless `--log-json` is set.
+* With `--log-json`, the logger writes a structured line to stdout and the
+  distances payload is suppressed.
+* `--format csv` accepts comma- or tab-separated files (so `.tsv` works).
+* `--format jsonl` accepts `.json` and `.jsonl` line-delimited inputs.
+
+CLI reference (grouped):
+
+Input:
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--edges PATH` | required (unless `--random`/`--example`) | Input edges file. |
+| `--random` | false | Generate a random graph. |
+| `--example` | false | Print a sample CSV and exit. |
+| `--format {csv,jsonl,mtx,graphml}` | auto | Input format override. |
+| `--n` | 10 | Vertex count for random graphs. |
+| `--m` | 20 | Edge count for random graphs. |
+| `--seed` | 0 | Random graph seed. |
+
+Solver:
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--source ID` | 0 | Single source vertex id. |
+| `--sources LIST` | none | Comma-separated source ids. |
+| `--target ID` | none | Target id for path output. |
+| `--frontier {block,heap}` | `block` | Frontier implementation. |
+| `--no-transform` | false | Disable constant-outdegree transform. |
+| `--target-outdeg N` | 4 | Outdegree cap when transforming. |
+
+Output:
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--export-json PATH` | none | Write DAG as JSON. |
+| `--export-graphml PATH` | none | Write DAG as GraphML. |
+| `--metrics-out PATH` | none | Write run metrics JSON. |
+| `--profile` | false | Enable cProfile. |
+| `--profile-out PATH` | none | Write `.prof` file. |
+
+Logging:
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--log-json` | false | Emit structured log line. |
+| `--log-level {debug,info,warning}` | `warning` | Log verbosity. |
+| `--verbose` | false | Show full tracebacks. |
 
 ---
 


### PR DESCRIPTION
## Summary

- Documented BMSSP safety limits and how to detect early termination.
- Added “Large graphs” troubleshooting guidance.
- Expanded CLI section with additional examples, behavioral notes, and a grouped flag reference.

## Testing

- `pre-commit run --files <files>`
- `pydocstyle src/ssspx`
- `poetry run pytest -q`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified BMSSP solver safety limits and how to detect early termination, plus added guidance for large graphs to help diagnose unexpected inf distances. Expanded the CLI reference with examples, behavioral notes, and a grouped flag table to make the tool easier to use.

<sup>Written for commit bbf19eaac31d81203b9c0b0940b0f3b8df117a9b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

