### PR TITLE
fix(ci): repair semantic release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,17 +175,10 @@ jobs:
       - name: Install deps
         timeout-minutes: 5
         run: poetry install
-      - name: Build distributions
-        run: poetry build
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: dist
-          path: dist/*
-      - name: Publish release
+      - name: Create version, tag, and release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: poetry run semantic-release publish --skip-build
+        run: poetry run semantic-release version
 
   extras:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ interrogate = "^1.7.0"
 ssspx = "ssspx.cli:main"
 
 [tool.semantic_release]
-version_toml = "pyproject.toml:tool.poetry.version"
+version_toml = ["pyproject.toml:tool.poetry.version"]
 version_variables = ["src/ssspx/__init__.py:__version__"]
 branch = "main"
 build_command = "poetry build"


### PR DESCRIPTION
Fix the main release workflow to use the current python-semantic-release CLI and update semantic-release config to the expected schema.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix semantic-release on main by switching the CI to the current `python-semantic-release` CLI and aligning config with the expected schema. Restores versioning, tagging, and GitHub release without deprecated flags.

- **Bug Fixes**
  - Replace `semantic-release publish --skip-build` with `semantic-release version` to create the version, tag, and GitHub release using `GH_TOKEN`.
  - Remove manual build and artifact upload steps from the workflow.
  - Update `version_toml` in `pyproject.toml` to array form to match the new schema.

<sup>Written for commit be8d7a7075a8eb72a5e6d212a74a56868f5e47fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/bmssp/pull/125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

