### PR TITLE
fix(ci): allow release job to push tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,8 @@ jobs:
     timeout-minutes: 15
     needs: [integration, docs]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6


### PR DESCRIPTION
Grant contents write permissions so the main release job can push the semantic-release commit and tag.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Grant `contents: write` permission to the main release job so `semantic-release` can push the release commit and tag. Fixes failed releases on `main` pushes caused by insufficient token permissions.

<sup>Written for commit 58113187bf3cce7e41dff582d5446eb61ac0b4ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/bmssp/pull/126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

