### PR TITLE
Sync main back into develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,8 @@ jobs:
     timeout-minutes: 15
     needs: [integration, docs]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,17 +175,10 @@ jobs:
       - name: Install deps
         timeout-minutes: 5
         run: poetry install
-      - name: Build distributions
-        run: poetry build
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: dist
-          path: dist/*
-      - name: Publish release
+      - name: Create version, tag, and release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: poetry run semantic-release publish --skip-build
+        run: poetry run semantic-release version
 
   extras:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ interrogate = "^1.7.0"
 ssspx = "ssspx.cli:main"
 
 [tool.semantic_release]
-version_toml = "pyproject.toml:tool.poetry.version"
+version_toml = ["pyproject.toml:tool.poetry.version"]
 version_variables = ["src/ssspx/__init__.py:__version__"]
 branch = "main"
 build_command = "poetry build"


### PR DESCRIPTION
Bring the release workflow fixes merged on main back into develop so branch flow is consistent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backports the release workflow fixes so `develop` matches `main` and automated versioning/tags work reliably via `semantic-release`.

- **Bug Fixes**
  - CI: add `permissions: contents: write` to the release job to allow pushing tags on `main`.
  - CI: replace `poetry run semantic-release publish --skip-build` with `poetry run semantic-release version`; remove build and artifact upload steps.
  - Config: change `version_toml` to a list in `pyproject.toml` for correct `semantic-release` parsing.

<sup>Written for commit 7a1171eb1169fde834885e5bc0563eba4288fffc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/bmssp/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

