### PR TITLE
fix(ci): use maintainer token for releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
@@ -179,7 +181,7 @@ jobs:
         run: poetry install
       - name: Create version, tag, and release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT != '' && secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
         run: poetry run semantic-release version
 
   extras:


### PR DESCRIPTION
## Summary
- fetch full git history in the release job so semantic-release can see tags
- prefer a repository secret RELEASE_PAT for release pushes on main
- fall back to GITHUB_TOKEN when that secret is not set

## Why
main is protected with a pull-request-only rule. On this user-owned repository, GitHub does not support adding the Actions app to a bypass list, so the release job needs to authenticate as a maintainer account instead of github-actions[bot].

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fetch full git history and use a maintainer token in the release job so semantic-release can find tags and push to protected `main`.
If `RELEASE_PAT` is not set, the job falls back to `GITHUB_TOKEN`.

<sup>Written for commit 9bcfd0535224299e9345d7a606a3bce9b63a165d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/bmssp/pull/128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

