### PR TITLE
Release workflow fixes from develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
@@ -179,7 +181,7 @@ jobs:
         run: poetry install
       - name: Create version, tag, and release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT != '' && secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
         run: poetry run semantic-release version
 
   extras:


### PR DESCRIPTION
## Summary
- bring the release workflow repair back to main through the normal develop -> main path
- let the release job use RELEASE_PAT when pushing version commits and tags
- fetch full git history so semantic-release can see existing tags

## Context
This replaces the earlier direct-to-main repair flow with the repository's intended promotion path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix release workflow by using `RELEASE_PAT` when pushing version commits and tags (fallback to `GITHUB_TOKEN`). Fetch the full git history so `semantic-release` detects existing tags.

<sup>Written for commit 45db6c97a30d2597337f388d801aa3841f62cc80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/bmssp/pull/129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

