### PR TITLE
fix(ci): use maintainer token for release checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT != '' && secrets.RELEASE_PAT || github.token }}
       - uses: actions/setup-python@v6
         with:
           python-version: '3.11'


### PR DESCRIPTION
## Summary
- make the elease checkout step use RELEASE_PAT when available
- keep the existing semantic-release GH_TOKEN fallback aligned with that token

## Why
The prior fix only changed semantic-release's environment. ctions/checkout still persisted GITHUB_TOKEN into git auth, so git push continued to hit main as github-actions[bot] and was rejected by the PR-only protection.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use a maintainer token for release checkout so pushes use a maintainer identity and are allowed on protected branches. We now pass `secrets.RELEASE_PAT` to `actions/checkout@v6` (fallback to `github.token`), fixing rejections when pushes came from `github-actions[bot]`.

<sup>Written for commit 1a0614cfe87dc50bf7501ea7cdd204b39324c59e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/bmssp/pull/130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

