### PR TITLE
Promote release checkout token fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT != '' && secrets.RELEASE_PAT || github.token }}
       - uses: actions/setup-python@v6
         with:
           python-version: '3.11'


### PR DESCRIPTION
## Summary
- promote the release checkout token fix from develop to main
- keep the main release job authenticated as the maintainer token when pushing version commits and tags

## Context
The previous main release run still failed because ctions/checkout persisted GITHUB_TOKEN into git auth, overriding the earlier semantic-release-only token fallback.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `actions/checkout` to use the maintainer `RELEASE_PAT` for the release job, falling back to `github.token` when absent. This prevents `GITHUB_TOKEN` from overwriting git auth so version commits and tags push successfully.

<sup>Written for commit 4ceb2110f2b562bb440500944fa07e1ceff0a223. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/bmssp/pull/131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

