### PR TITLE
Promote Zenodo metadata fix

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,7 +1,6 @@
 {
   "title": "ssspx: Production-grade Single-Source Shortest Paths",
   "description": "Reference implementation of the deterministic BMSSP algorithm from \"Breaking the Sorting Barrier for Directed Single-Source Shortest Paths\" (Duan, Mao, Mao, Shu, Yin), with tests and benchmarks for directed graphs with non-negative weights.",
-  "version": "v0.1.3",
   "upload_type": "software",
   "access_right": "open",
 
@@ -36,4 +35,3 @@
     }
   ]
 }
-

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,9 +9,7 @@ authors:
     email: dfr@esmad.ipp.pt
     affiliation: ESMAD - Instituto Politécnico do Porto
 license: MIT
-version: "0.1.0"
-doi: 10.5281/zenodo.17381998
-date-released: 2024-09-01
+doi: 10.5281/zenodo.17381904
 repository-code: "https://github.com/DiogoRibeiro7/bmssp"
 keywords:
   - graphs
@@ -26,9 +24,7 @@ preferred-citation:
       given-names: Diogo
       orcid: "https://orcid.org/0009-0001-2022-7072"
   title: ssspx
-  version: "0.1.0"
-  doi: 10.5281/zenodo.17381998
+  doi: 10.5281/zenodo.17381904
   url: https://github.com/DiogoRibeiro7/bmssp
   publisher:
     name: Zenodo
-  date-released: 2024-09-01

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ssspx — Production-grade Single-Source Shortest Paths (Python)
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17381998.svg)](https://doi.org/10.5281/zenodo.17381998)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17381904.svg)](https://doi.org/10.5281/zenodo.17381904)
 
 <!-- GitHub stars/forks -->
 
@@ -281,7 +281,7 @@ track the upstream resolution.
 
 Configured for **semantic-release** with Conventional Commits (Angular style). On pushes to `main`, it bumps the version, updates `CHANGELOG.md`, and creates a GitHub Release.
 
-Releases are archived on **Zenodo**. The latest release DOI is **[10.5281/zenodo.17381998](https://doi.org/10.5281/zenodo.17381998)** (badge at the top).
+Releases are archived on **Zenodo**. The archive DOI is **[10.5281/zenodo.17381904](https://doi.org/10.5281/zenodo.17381904)** (badge at the top).
 
 Common prefixes: `feat:`, `fix:`, `perf:`, `refactor:`, `docs:`, `test:`, `chore:`.
 
@@ -302,7 +302,7 @@ If you use `ssspx` in academic work, please cite:
   author    = {Ribeiro, Diogo},
   title     = {ssspx — Production-grade Single-Source Shortest Paths (Python)},
   year      = {2025},
-  doi       = {10.5281/zenodo.17381998},
+  doi       = {10.5281/zenodo.17381904},
   url       = {https://github.com/DiogoRibeiro7/bmssp},
   publisher = {Zenodo}
 }


### PR DESCRIPTION
## Summary
- promote the Zenodo metadata fix from develop to main
- stop overriding release version metadata through .zenodo.json
- align repository-facing citation references with the Zenodo concept DOI

## Why
The previous GitHub release archived the correct files in Zenodo, but Zenodo kept showing the old version because the repository still hardcoded 0.1.3 in .zenodo.json.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Zenodo metadata so the latest release displays correctly and citations use the stable concept DOI across the repo. Removes the pinned version and updates references to the concept DOI.

- **Bug Fixes**
  - Removed the hardcoded "version" from `.zenodo.json` so Zenodo uses the current release.
  - Updated `CITATION.cff` and `README.md` to the concept DOI 10.5281/zenodo.17381904 and dropped stale version/date fields.

<sup>Written for commit 1e33d7e7c8a8c31d126e46656206ff02253af809. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/bmssp/pull/133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

