### PR TITLE
ci(build): simplify package build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build wheels
+name: Build package
 
 on:
   push:
@@ -6,30 +6,7 @@ on:
       - 'v*'
 
 jobs:
-  linux-macos:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.11'
-      - name: Install build tooling
-        run: |
-          python -m pip install --upgrade pip
-          pip install poetry cibuildwheel
-          poetry install --only main
-      - name: Build wheels
-        run: |
-          cibuildwheel --output-dir dist
-      - uses: actions/upload-artifact@v7
-        with:
-          name: wheels-${{ matrix.os }}
-          path: dist/*.whl
-
-  sdist:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -37,10 +14,12 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install Poetry
-        run: pip install poetry
-      - name: Build sdist
-        run: poetry build -f sdist
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+      - name: Build distributions
+        run: poetry build
       - uses: actions/upload-artifact@v7
         with:
-          name: sdist
-          path: dist/*.tar.gz
+          name: dist
+          path: dist/*


### PR DESCRIPTION
## Summary
- replace the tag build matrix with a single Ubuntu job
- stop using cibuildwheel for a pure-Python package
- build and upload both wheel and sdist with plain poetry build

## Why
The macOS leg was unnecessary, and cibuildwheel was adding platform complexity for a package that already builds a universal py3-none-any wheel.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streamlined the tag build workflow by replacing the Linux/macOS matrix with a single Ubuntu job and building both wheel and sdist with `poetry build`. Removed `cibuildwheel` since this pure-Python package ships a universal wheel, and now upload a single `dist` artifact.

<sup>Written for commit e29444a67175122cc39279153c41cd2e6e7e3ae9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/bmssp/pull/134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

