### PR TITLE
Promote simplified package build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build wheels
+name: Build package
 
 on:
   push:
@@ -6,30 +6,7 @@ on:
       - 'v*'
 
 jobs:
-  linux-macos:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.11'
-      - name: Install build tooling
-        run: |
-          python -m pip install --upgrade pip
-          pip install poetry cibuildwheel
-          poetry install --only main
-      - name: Build wheels
-        run: |
-          cibuildwheel --output-dir dist
-      - uses: actions/upload-artifact@v7
-        with:
-          name: wheels-${{ matrix.os }}
-          path: dist/*.whl
-
-  sdist:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -37,10 +14,12 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install Poetry
-        run: pip install poetry
-      - name: Build sdist
-        run: poetry build -f sdist
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+      - name: Build distributions
+        run: poetry build
       - uses: actions/upload-artifact@v7
         with:
-          name: sdist
-          path: dist/*.tar.gz
+          name: dist
+          path: dist/*


### PR DESCRIPTION
## Summary
- promote the simplified tag build workflow from develop to main
- remove the macOS build leg
- replace cibuildwheel with a single Ubuntu poetry build

## Why
This package is pure Python, so platform wheel builds were unnecessary complexity and were the source of the macOS failure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies the release workflow by building both sdist and wheel on Ubuntu using `poetry`. Removes macOS and `cibuildwheel`, reducing CI complexity and avoiding the macOS failure on tag builds.

- **Refactors**
  - Replace the Ubuntu+macOS matrix with a single `ubuntu-latest` job.
  - Use `poetry build` to produce sdist and wheel; upload a single `dist/*` artifact.

<sup>Written for commit 2df372a307507168aa5dcc2e1c673165bd181e10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/bmssp/pull/135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

